### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @redhat-appstudio/book-publishers will be requested for
+# review when someone opens a pull request.
+*       @redhat-appstudio/book-publishers


### PR DESCRIPTION
We can assign more specific review ownership to things like architecture/build-service.md and architecture/enterprise-contract.md in the future if we want to.