### PR TITLE
Update has component types doc

### DIFF
--- a/architecture/HAS/hybrid-application-service-component-types.md
+++ b/architecture/HAS/hybrid-application-service-component-types.md
@@ -33,7 +33,7 @@ Quarkus
 - If a .dockerignore file is present, make sure that a wildcard, *, entry is not present, as AppStudio builds the Application source as part of the Container build
 
 Python
-- Pip is used to manage dependencies for AppStudio Python projects. Make sure that your project has a requirements.txt at the root
+- Pip is used to manage dependencies for AppStudio Python projects. Make sure that your project has a requirements.txt or a pyproject.toml file at the root.
 
 NodeJS
 - HAS expects NodeJS based Components to have a package.json at the Component's base folder


### PR DESCRIPTION
Simply adds the `pyproject.toml` as a type of file that can make a source code identified as a python-based if it exists in the root directory.